### PR TITLE
fix: 🐛 fix template and attribut isId for generation template entity

### DIFF
--- a/src/main/java/com/cli/springx/command/GenerateEntityCommand.java
+++ b/src/main/java/com/cli/springx/command/GenerateEntityCommand.java
@@ -66,7 +66,7 @@ public class GenerateEntityCommand implements Runnable {
 
     Entity entity = new Entity(entityName);
     // Ajout d'un id par défaut
-    entity.addAttributs(new Attributs("id", "Long"));
+    entity.addAttributs(new Attributs("id", "Long", true));
 
     // Lecture attributs
     while (true) {

--- a/src/main/java/com/cli/springx/model/Attributs.java
+++ b/src/main/java/com/cli/springx/model/Attributs.java
@@ -4,6 +4,7 @@ public class Attributs {
 
   private String name;
   private String type;
+  private boolean isId;
 
   public Attributs() {
   }
@@ -11,6 +12,20 @@ public class Attributs {
   public Attributs(String name, String type) {
     this.name = name;
     this.type = type;
+  }
+
+  public Attributs(String name, String type, boolean isId) {
+    this.name = name;
+    this.type = type;
+    this.isId = isId;
+  }
+
+  public boolean isId() {
+    return isId;
+  }
+
+  public void setId(boolean isId) {
+    this.isId = isId;
   }
 
   public String getName() {

--- a/src/main/resources/templates/entity.tpl
+++ b/src/main/resources/templates/entity.tpl
@@ -17,7 +17,7 @@ import lombok.AllArgsConstructor;
 public class {{EntityName}} {
 
     {{#each attributes}}
-    {{#if name = "id"}}
+    {{#if isId}}
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     {{/if}}


### PR DESCRIPTION
This pull request introduces enhancements to the entity generation functionality in the CLI tool. The changes primarily focus on adding support for identifying attributes as primary keys (`id`) and updating the template logic accordingly.

### Entity generation improvements:

* [`src/main/java/com/cli/springx/command/GenerateEntityCommand.java`](diffhunk://#diff-5a239dc10b280fa2763a4bf950076b269817ff6c6dcc4a115141f02a00bca5d6L69-R69): Modified the default attribute creation for `id` to include a new boolean flag (`isId`) indicating it is a primary key.

### Attribute model updates:

* [`src/main/java/com/cli/springx/model/Attributs.java`](diffhunk://#diff-fc4db17dfa95b5221f7c078b14d7a87064ea3f6b875204659118b13ac04000f2R7): Added a new `isId` property to the `Attributs` class, along with corresponding getter and setter methods. Introduced a new constructor to initialize the `isId` property. [[1]](diffhunk://#diff-fc4db17dfa95b5221f7c078b14d7a87064ea3f6b875204659118b13ac04000f2R7) [[2]](diffhunk://#diff-fc4db17dfa95b5221f7c078b14d7a87064ea3f6b875204659118b13ac04000f2R17-R30)

### Template logic adjustments:

* [`src/main/resources/templates/entity.tpl`](diffhunk://#diff-13f399b71e141b02a11023edb4a0f2622cd97f75b734adbbdeafcc257422bcc3L20-R20): Updated the template logic to use the new `isId` property for determining if an attribute is a primary key, replacing the previous hardcoded check for the name `id`.